### PR TITLE
sitrep: Add integration test for receive protocol version check

### DIFF
--- a/.github/workflows/sitrepCi.yml
+++ b/.github/workflows/sitrepCi.yml
@@ -17,6 +17,10 @@
                 {
                     "name": "Run unit tests",
                     "run": "UNITTEST=Y build/artifact/sitrep-sitrep-receive/sitrep-receive"
+                },
+                {
+                    "name": "Run integration tests",
+                    "run": "/nix/var/nix/profiles/default/bin/nix run -ic env INTEGRATIONTEST=Y build/artifact/sitrep-hivemind.bash/hivemind.bash && (exit \"$(< state/prove.status)\")"
                 }
             ]
         }

--- a/default.nix
+++ b/default.nix
@@ -14,9 +14,11 @@ in
         pkgs.coreutils
         pkgs.docbook2html
         pkgs.findutils
+        pkgs.getLocaleArchive
         pkgs.gnused
         pkgs.hivemind
         pkgs.ldc
+        pkgs.perl
         pkgs.shellcheck
         pkgs.snowflake
         pkgs.socat

--- a/nix/getLocaleArchive.nix
+++ b/nix/getLocaleArchive.nix
@@ -1,0 +1,11 @@
+{stdenvNoCC, coreutils, glibcLocales, makeWrapper}:
+stdenvNoCC.mkDerivation {
+    name = "getLocaleArchive";
+    buildInputs = [makeWrapper];
+    phases = ["installPhase"];
+    installPhase = ''
+        mkdir --parents $out/bin
+        makeWrapper ${coreutils}/bin/echo $out/bin/getLocaleArchive \
+            --add-flags ${glibcLocales}/lib/locale/locale-archive
+    '';
+}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -9,6 +9,7 @@ let
             pkg-configWithPackages =
                 pkgs.callPackage ./pkg-configWithPackages.nix {};
             snowflake = pkgs.callPackage ./snowflake.nix {};
+            getLocaleArchive = pkgs.callPackage ./getLocaleArchive.nix {};
         };
     };
 in

--- a/sitrep/doc/testing.xml
+++ b/sitrep/doc/testing.xml
@@ -9,4 +9,14 @@
         In this case, the program will stop running
         after executing the unit tests.
     </para>
+    <para>
+        The integration tests span across programs.
+        They test the system as a whole.
+        To run the integration tests,
+        invoke <command>hivemind.bash</command>
+        with the <envar>INTEGRATIONTEST</envar> variable set
+        to the value <userinput>Y</userinput>.
+        In this case, Hivemind will stop running
+        after executing the integration tests.
+    </para>
 </chapter>

--- a/sitrep/hivemind/Procfile
+++ b/sitrep/hivemind/Procfile
@@ -1,3 +1,4 @@
 sitrep-receive: PGHOST=$PWD/state/sitrep/database/sockets PGUSER=sitrep_receive PGPASSWORD=$PGUSER PGDATABASE=sitrep socat -d TCP-LISTEN:1080,fork,reuseaddr EXEC:@SITREP_RECEIVE@/sitrep-receive
 postgresql: postgres --config-file=@POSTGRESQL_CONF@/postgresql.conf -k $PWD/state/sitrep/database/sockets
 database-setup: @SETUP_BASH@/setup.bash && sleep infinity
+integration-test: if [ "$INTEGRATIONTEST" = Y ]; then sleep 2.5 && prove --recurse --verbose @INTEGRATION_TEST@/t; echo $? > state/prove.status; else sleep infinity; fi

--- a/sitrep/hivemind/build.pm
+++ b/sitrep/hivemind/build.pm
@@ -7,11 +7,13 @@ use Snowflake::Rule;
 use Snowflake::Rule::Util qw(bash_strict);
 
 use sitrep::database::build;
+use sitrep::integrationTest::build;
 use sitrep::receive::build;
 
 our $procfile = Snowflake::Rule->new(
     name => 'sitrep » hivemind » Procfile',
     dependencies => [
+        $sitrep::integrationTest::build::integrationTest,
         $sitrep::database::build::postgresql_conf,
         $sitrep::database::build::setup_bash,
         $sitrep::receive::build::sitrep_receive,
@@ -20,10 +22,12 @@ our $procfile = Snowflake::Rule->new(
         'Procfile.template' =>
             ['on_disk', 'sitrep/hivemind/Procfile'],
         'snowflake-build' => bash_strict(<<'BASH'),
-            postgresql_conf=${1#../../../}
-            setup_bash=${2#../../../}
-            sitrep_receive=${3#../../../}
+            integration_test=${1#../../../}
+            postgresql_conf=${2#../../../}
+            setup_bash=${3#../../../}
+            sitrep_receive=${4#../../../}
             sed --file=- Procfile.template > Procfile <<SED
+                s:@INTEGRATION_TEST@:$integration_test:g
                 s:@POSTGRESQL_CONF@:$postgresql_conf:g
                 s:@SETUP_BASH@:$setup_bash:g
                 s:@SITREP_RECEIVE@:$sitrep_receive:g
@@ -42,8 +46,10 @@ our $hivemind_bash = Snowflake::Rule->new(
         'hivemind.bash.template' =>
             ['on_disk', 'sitrep/hivemind/hivemind.bash'],
         'snowflake-build' => bash_strict(<<'BASH'),
+            localeArchive=$(getLocaleArchive)
             procfile=${1#../../../}
             sed --file=- hivemind.bash.template > hivemind.bash <<SED
+                s:@LOCALE_ARCHIVE@:$localeArchive:g
                 s:@PROCFILE@:$procfile:g
 SED
 

--- a/sitrep/hivemind/hivemind.bash
+++ b/sitrep/hivemind/hivemind.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -efuo pipefail
 
+export LOCALE_ARCHIVE=@LOCALE_ARCHIVE@
+
 if (( $# != 0 )); then
     1>&2 echo "$0: This command takes no arguments"
     exit 1

--- a/sitrep/integrationTest/build.pm
+++ b/sitrep/integrationTest/build.pm
@@ -1,0 +1,21 @@
+package sitrep::integrationTest::build;
+
+use v5.12;
+use warnings;
+
+use Snowflake::Rule;
+use Snowflake::Rule::Util qw(bash_strict);
+
+our $integrationTest = Snowflake::Rule->new(
+    name => 'sitrep » integrationTest » integrationTest',
+    dependencies => [],
+    sources => {
+        'receive' => ['on_disk', 'sitrep/receive/t'],
+        'snowflake-build' => bash_strict(<<'BASH'),
+            mkdir --parents snowflake-output/t
+            mv receive snowflake-output/t
+BASH
+    },
+);
+
+1;

--- a/sitrep/receive/t/protocolVersion.t
+++ b/sitrep/receive/t/protocolVersion.t
@@ -1,0 +1,25 @@
+use v5.12;
+use strict;
+
+use IO::Socket::INET;
+use Test::More tests => 101;
+
+use constant BadProtocolVersion => 0x0000;
+use constant ProtocolVersionOk  => 0x0004;
+
+sub sendRequest
+{
+    my $req = pack('S<', shift);
+    my $res;
+    my $socket = IO::Socket::INET->new(PeerAddr => '127.0.0.1:1080');
+    $socket->print($req);
+    $socket->read($res, 2);
+    $socket->close;
+    unpack('S<', $res);
+}
+
+my @okVersions  = (0);
+my @badVersions = map { int(1 + rand(2 ** 16 - 1)) } 1 .. 100;
+
+is(sendRequest($_), ProtocolVersionOk,  "OK version $_" ) for @okVersions;
+is(sendRequest($_), BadProtocolVersion, "Bad version $_") for @badVersions;


### PR DESCRIPTION
To run the integration tests on CI, we need to set LOCALE_ARCHIVE.
This change includes a program that prints LOCALE_ARCHIVE, so that the build
script can find it under “nix run”.