### PR TITLE
sitrep: Run and set up PostgreSQL outside of Hivemind

### DIFF
--- a/.github/workflows/sitrepCi.yml
+++ b/.github/workflows/sitrepCi.yml
@@ -20,7 +20,7 @@
                 },
                 {
                     "name": "Run integration tests",
-                    "run": "/nix/var/nix/profiles/default/bin/nix run -ic env INTEGRATIONTEST=Y build/artifact/sitrep-hivemind.bash/hivemind.bash && (exit \"$(< state/prove.status)\")"
+                    "run": "/nix/var/nix/profiles/default/bin/nix run -ic build/artifact/sitrep-database-with.bash/with.bash env INTEGRATIONTEST=Y build/artifact/sitrep-hivemind.bash/hivemind.bash && (exit \"$(< state/integration-test.status)\")"
                 }
             ]
         }

--- a/sitrep/build.pm
+++ b/sitrep/build.pm
@@ -9,6 +9,7 @@ use sitrep::receive::build;
 
 our %artifacts = (
     'sitrep-doc' => $sitrep::doc::build::doc,
+    'sitrep-database-with.bash' => $sitrep::database::build::with_bash,
     'sitrep-hivemind.bash' => $sitrep::hivemind::build::hivemind_bash,
     'sitrep-sitrep-receive' => $sitrep::receive::build::sitrep_receive,
 );

--- a/sitrep/database/build.pm
+++ b/sitrep/database/build.pm
@@ -86,4 +86,30 @@ BASH
     },
 );
 
+our $with_bash = Snowflake::Rule->new(
+    name => 'sitrep » database » with.bash',
+    dependencies => [
+        $postgresql_conf,
+        $setup_bash,
+    ],
+    sources => {
+        'with.bash.template' =>
+            ['on_disk', 'sitrep/database/with.bash'],
+        'snowflake-build' => bash_strict(<<'BASH'),
+            postgresql_conf=${1#../../../}
+            setup_bash=${2#../../../}
+            sed --file=- with.bash.template > with.bash <<SED
+                s:@POSTGRESQL_CONF@:$postgresql_conf:g
+                s:@SETUP_BASH@:$setup_bash:g
+SED
+
+            chmod +x with.bash
+            shellcheck with.bash
+
+            mkdir snowflake-output
+            mv with.bash snowflake-output
+BASH
+    },
+);
+
 1;

--- a/sitrep/database/setup.bash
+++ b/sitrep/database/setup.bash
@@ -1,49 +1,38 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2030,SC2031
 set -efuo pipefail
 
 stateDir=$PWD/state/sitrep/database
 
 export PGHOST="$stateDir/sockets"
+export PGPORT=5432
 
-(
-    export PGUSER=postgres
-    export PGPASSWORD=$PGUSER
-    while ! pg_isready; do
-        sleep 0.1
-    done
-)
+export PGUSER=postgres
+export PGPASSWORD=$PGUSER
+export PGDATABASE=postgres
+mkdir --parents "$stateDir/tablespaces/sitrep_log_messages_in_need_of_extraction"
+mkdir --parents "$stateDir/tablespaces/sitrep_log_messages_extracted_from"
+psql --file=- <<SQL
+    CREATE ROLE sitrep_migrate LOGIN BYPASSRLS PASSWORD 'sitrep_migrate';
+    CREATE ROLE sitrep_receive LOGIN PASSWORD 'sitrep_receive';
 
-(
-    export PGUSER=postgres
-    export PGPASSWORD=$PGUSER
-    mkdir --parents "$stateDir/tablespaces/sitrep_log_messages_in_need_of_extraction"
-    mkdir --parents "$stateDir/tablespaces/sitrep_log_messages_extracted_from"
-    psql --file=- <<SQL
-        CREATE ROLE sitrep_migrate LOGIN BYPASSRLS PASSWORD 'sitrep_migrate';
-        CREATE ROLE sitrep_receive LOGIN PASSWORD 'sitrep_receive';
+    CREATE DATABASE sitrep OWNER sitrep_migrate;
 
-        CREATE DATABASE sitrep OWNER sitrep_migrate;
+    CREATE TABLESPACE sitrep_log_messages_in_need_of_extraction
+        LOCATION '$stateDir/tablespaces/sitrep_log_messages_in_need_of_extraction';
 
-        CREATE TABLESPACE sitrep_log_messages_in_need_of_extraction
-            LOCATION '$stateDir/tablespaces/sitrep_log_messages_in_need_of_extraction';
+    CREATE TABLESPACE sitrep_log_messages_extracted_from
+        LOCATION '$stateDir/tablespaces/sitrep_log_messages_extracted_from';
 
-        CREATE TABLESPACE sitrep_log_messages_extracted_from
-            LOCATION '$stateDir/tablespaces/sitrep_log_messages_extracted_from';
+    GRANT CREATE ON TABLESPACE sitrep_log_messages_in_need_of_extraction TO sitrep_migrate;
+    GRANT CREATE ON TABLESPACE sitrep_log_messages_extracted_from TO sitrep_migrate;
 
-        GRANT CREATE ON TABLESPACE sitrep_log_messages_in_need_of_extraction TO sitrep_migrate;
-        GRANT CREATE ON TABLESPACE sitrep_log_messages_extracted_from TO sitrep_migrate;
+    \\connect sitrep
 
-        \\connect sitrep
-
-        DROP SCHEMA public;
+    DROP SCHEMA public;
 SQL
-)
 
-(
-    export PGUSER=sitrep_migrate
-    export PGPASSWORD=$PGUSER
-    export PGDATABASE=sitrep
-    cd @SCHEMA@
-    sqitch deploy
-)
+export PGUSER=sitrep_migrate
+export PGPASSWORD=$PGUSER
+export PGDATABASE=sitrep
+cd @SCHEMA@
+sqitch deploy

--- a/sitrep/database/with.bash
+++ b/sitrep/database/with.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -efuo pipefail
+
+trap 'kill -TERM $(jobs -pr)' SIGINT SIGTERM EXIT
+
+LOCALE_ARCHIVE=$(getLocaleArchive)
+export LOCALE_ARCHIVE
+
+stateDir=$PWD/state/sitrep/database
+
+if ! [[ -e $stateDir/data ]]; then
+    initdb                          \
+        --pgdata="$stateDir/data"   \
+        --username=postgres         \
+        --pwfile=<(echo postgres)   \
+        --locale=en_US.UTF-8
+    find "$stateDir/data" -name '*.conf' -delete
+fi
+
+mkdir --parents "$stateDir/sockets"
+
+postgres \
+    --config-file=@POSTGRESQL_CONF@/postgresql.conf \
+    -k "$stateDir/sockets" \
+    &
+
+export PGHOST=$stateDir/sockets
+export PGPORT=5432
+
+(
+    export PGUSER=postgres
+    export PGPASSWORD=$PGUSER
+    while ! pg_isready; do
+        sleep 0.1
+    done
+)
+
+@SETUP_BASH@/setup.bash
+
+# Do not use exec; that would inhibit the trap.
+"$@"

--- a/sitrep/hivemind/Procfile
+++ b/sitrep/hivemind/Procfile
@@ -1,4 +1,2 @@
-sitrep-receive: PGHOST=$PWD/state/sitrep/database/sockets PGUSER=sitrep_receive PGPASSWORD=$PGUSER PGDATABASE=sitrep socat -d TCP-LISTEN:1080,fork,reuseaddr EXEC:@SITREP_RECEIVE@/sitrep-receive
-postgresql: postgres --config-file=@POSTGRESQL_CONF@/postgresql.conf -k $PWD/state/sitrep/database/sockets
-database-setup: @SETUP_BASH@/setup.bash && sleep infinity
-integration-test: if [ "$INTEGRATIONTEST" = Y ]; then sleep 2.5 && PGHOST=$PWD/state/sitrep/database/sockets PGUSER=sitrep_migrate PGPASSWORD=$PGUSER PGDATABASE=sitrep psql --file=@INTEGRATION_TEST@/seed.sql && prove --recurse --verbose @INTEGRATION_TEST@/t; echo $? > state/prove.status; else sleep infinity; fi
+integration-test: @INTEGRATION_TEST_BASH@/integration-test.bash; echo $? > state/integration-test.status
+sitrep-receive: @SITREP_RECEIVE_BASH@/sitrep-receive.bash

--- a/sitrep/hivemind/build.pm
+++ b/sitrep/hivemind/build.pm
@@ -10,27 +10,66 @@ use sitrep::database::build;
 use sitrep::integrationTest::build;
 use sitrep::receive::build;
 
-our $procfile = Snowflake::Rule->new(
-    name => 'sitrep » hivemind » Procfile',
+our $integration_test_bash = Snowflake::Rule->new(
+    name => 'sitrep » hivemind » integration_test.bash',
     dependencies => [
         $sitrep::integrationTest::build::integrationTest,
-        $sitrep::database::build::postgresql_conf,
-        $sitrep::database::build::setup_bash,
+    ],
+    sources => {
+        'integration-test.bash' =>
+            ['on_disk', 'sitrep/hivemind/integration-test.bash'],
+        'snowflake-build' => bash_strict(<<'BASH'),
+            integration_test=${1#../../../}
+            sed --file=- --in-place integration-test.bash <<SED
+                s:@INTEGRATION_TEST@:$integration_test:g
+SED
+
+            chmod +x integration-test.bash
+            shellcheck integration-test.bash
+
+            mkdir snowflake-output
+            mv integration-test.bash snowflake-output
+BASH
+    },
+);
+
+our $sitrep_receive_bash = Snowflake::Rule->new(
+    name => 'sitrep » hivemind » sitrep-receive.bash',
+    dependencies => [
         $sitrep::receive::build::sitrep_receive,
     ],
     sources => {
-        'Procfile.template' =>
-            ['on_disk', 'sitrep/hivemind/Procfile'],
+        'sitrep-receive.bash' =>
+            ['on_disk', 'sitrep/hivemind/sitrep-receive.bash'],
         'snowflake-build' => bash_strict(<<'BASH'),
-            integration_test=${1#../../../}
-            postgresql_conf=${2#../../../}
-            setup_bash=${3#../../../}
-            sitrep_receive=${4#../../../}
-            sed --file=- Procfile.template > Procfile <<SED
-                s:@INTEGRATION_TEST@:$integration_test:g
-                s:@POSTGRESQL_CONF@:$postgresql_conf:g
-                s:@SETUP_BASH@:$setup_bash:g
+            sitrep_receive=${1#../../../}
+            sed --file=- --in-place sitrep-receive.bash <<SED
                 s:@SITREP_RECEIVE@:$sitrep_receive:g
+SED
+
+            chmod +x sitrep-receive.bash
+            shellcheck sitrep-receive.bash
+
+            mkdir snowflake-output
+            mv sitrep-receive.bash snowflake-output
+BASH
+    },
+);
+
+our $procfile = Snowflake::Rule->new(
+    name => 'sitrep » hivemind » Procfile',
+    dependencies => [
+        $integration_test_bash,
+        $sitrep_receive_bash,
+    ],
+    sources => {
+        'Procfile' => ['on_disk', 'sitrep/hivemind/Procfile'],
+        'snowflake-build' => bash_strict(<<'BASH'),
+            integration_test_bash=${1#../../../}
+            sitrep_receive_bash=${2#../../../}
+            sed --file=- --in-place Procfile <<SED
+                s:@INTEGRATION_TEST_BASH@:$integration_test_bash:g
+                s:@SITREP_RECEIVE_BASH@:$sitrep_receive_bash:g
 SED
 
             mkdir snowflake-output
@@ -43,13 +82,10 @@ our $hivemind_bash = Snowflake::Rule->new(
     name => 'sitrep » hivemind » hivemind.bash',
     dependencies => [$procfile],
     sources => {
-        'hivemind.bash.template' =>
-            ['on_disk', 'sitrep/hivemind/hivemind.bash'],
+        'hivemind.bash' => ['on_disk', 'sitrep/hivemind/hivemind.bash'],
         'snowflake-build' => bash_strict(<<'BASH'),
-            localeArchive=$(getLocaleArchive)
             procfile=${1#../../../}
-            sed --file=- hivemind.bash.template > hivemind.bash <<SED
-                s:@LOCALE_ARCHIVE@:$localeArchive:g
+            sed --file=- --in-place hivemind.bash <<SED
                 s:@PROCFILE@:$procfile:g
 SED
 

--- a/sitrep/hivemind/hivemind.bash
+++ b/sitrep/hivemind/hivemind.bash
@@ -1,24 +1,12 @@
 #!/usr/bin/env bash
 set -efuo pipefail
 
-export LOCALE_ARCHIVE=@LOCALE_ARCHIVE@
+LOCALE_ARCHIVE=$(getLocaleArchive)
+export LOCALE_ARCHIVE
 
 if (( $# != 0 )); then
     1>&2 echo "$0: This command takes no arguments"
     exit 1
-fi
-
-if ! [[ -e state/sitrep/database/data ]]; then
-    initdb                                  \
-        --pgdata=state/sitrep/database/data \
-        --username=postgres                 \
-        --pwfile=<(echo postgres)           \
-        --locale=en_US.UTF-8
-    find state/sitrep/database/data -name '*.conf' -delete
-fi
-
-if ! [[ -e state/sitrep/database/sockets ]]; then
-    mkdir state/sitrep/database/sockets
 fi
 
 exec hivemind --root "$PWD" @PROCFILE@/Procfile

--- a/sitrep/hivemind/integration-test.bash
+++ b/sitrep/hivemind/integration-test.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -efuo pipefail
+
+if [[ ${INTEGRATIONTEST:-} != Y ]]; then
+    exec sleep infinity
+fi
+
+export PGUSER=sitrep_migrate
+export PGPASSWORD=$PGUSER
+export PGDATABASE=sitrep
+
+psql --file=@INTEGRATION_TEST@/seed.sql
+
+exec prove --recurse --verbose @INTEGRATION_TEST@/t

--- a/sitrep/hivemind/sitrep-receive.bash
+++ b/sitrep/hivemind/sitrep-receive.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -efuo pipefail
+
+export PGUSER=sitrep_receive
+export PGPASSWORD=$PGUSER
+export PGDATABASE=sitrep
+
+exec socat -d TCP-LISTEN:1080,fork,reuseaddr EXEC:@SITREP_RECEIVE@/sitrep-receive


### PR DESCRIPTION
This eliminates the race condition where the tests already start running before
the database is set up. It is also faster, because it eliminates the sleep that
was used to “overcome” the race condition.

This change also extracts commands from Procfile into Bash files.